### PR TITLE
 use `completing-read` instead of ido-specific alternative

### DIFF
--- a/paperless.el
+++ b/paperless.el
@@ -107,7 +107,7 @@
 (defun paperless-file ()
   "Select the directory in which to file the current document."
   (interactive)
-  (let ((new-dir (ido-completing-read "File destination: " (paperless--dirtree)))
+  (let ((new-dir (completing-read "File destination: " (paperless--dirtree)))
 	(vctr (cadr (assoc (tabulated-list-get-id) paperless--table-contents))))
     (setf (elt vctr 2) new-dir))
   (tabulated-list-print t))


### PR DESCRIPTION
If you, for instance, prefer ivy, it will be used instead of ido